### PR TITLE
Solve bug in comp_duration function

### DIFF
--- a/src/scanner/utils.py
+++ b/src/scanner/utils.py
@@ -127,7 +127,10 @@ def comp_duration(curve):
 
     ini = str(df_aux["SE"].values[0])
     end = str(df_aux["SE"].values[-1])
-    dur = int(end[-2:]) - int(ini[-2:])
+
+    ini_aux = Week.fromstring(ini).startdate()
+    end_aux = Week.fromstring(end).startdate()
+    dur = int((end_aux - ini_aux).days / 7)
 
     ep_dur = {"ini": ini, "end": end, "dur": dur}
     return ep_dur


### PR DESCRIPTION
I found an error in the function `comp_duration`. Since now we are allowing the epi-scanner to fit over the whole year, sometimes the last week of the year is marked as `NEXTYEAR01`. In this case, the duration computed would be negative since it would use 1 as the week of the epidemic's end.  